### PR TITLE
fix lazy.nvim config, wrong new tab function

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Requires **Neovim >= 0.10**. For the best experience, install Treesitter’s `ma
   keys = {
     { "<leader>ww", "<cmd>lua require('neowiki').open_wiki()<cr>", desc = "Open Wiki" },
     { "<leader>wW", "<cmd>lua require('neowiki').open_wiki_floating()<cr>", desc = "Open Wiki in Floating Window" },
-    { "<leader>wT", "<cmd>lua require('neowiki').open_wiki_in_new_tab()<cr>", desc = "Open Wiki in Tab" },
+    { "<leader>wT", "<cmd>lua require('neowiki').open_wiki_new_tab()<cr>", desc = "Open Wiki in Tab" },
   },
 }
 ```


### PR DESCRIPTION
open_wiki_in_new_tab doesn't exist