### PR TITLE
Fix tool name for system that use a different binary name

### DIFF
--- a/lua/neowiki/core/finder.lua
+++ b/lua/neowiki/core/finder.lua
@@ -8,6 +8,17 @@ local M = {}
 -- Variable to ensure the fallback notification is only shown once per session.
 local native_fallback_notified = false
 
+
+local tools = {
+  fd  = { name = "fd", binaries = { "fd", "fdfind" } },
+  git = { name = "git" },
+  rg  = { name = "rg" },
+}
+
+local rg = util.check_binary_installed(tools.rg)
+local fd = util.check_binary_installed(tools.fd)
+local git = util.check_binary_installed(tools.git)
+
 ---
 -- Generic file finder that uses fast command-line tools if available.
 -- It prioritizes rg > fd > git, falling back to a native vim glob.
@@ -22,13 +33,13 @@ local find_files = function(search_path, search_term, search_type)
   local files
   local glob_pattern
 
-  if vim.fn.executable("rg") == 1 then
+  if rg then
     if search_type == "ext" then
       glob_pattern = "*" .. search_term
     else -- 'name'
       glob_pattern = search_term
     end
-    command = { "rg", "--files", "--no-follow", "--crlf", "--iglob", glob_pattern, search_path }
+    command = { rg.binary, "--files", "--no-follow", "--crlf", "--iglob", glob_pattern, search_path }
     files = vim.fn.systemlist(command)
     if vim.v.shell_error == 0 then
       -- rg can return relative paths; ensure they are absolute.
@@ -41,12 +52,12 @@ local find_files = function(search_path, search_term, search_type)
     end
   end
 
-  if vim.fn.executable("fd") == 1 then
+  if fd then
     if search_type == "ext" then
       -- fd expects the extension without the dot.
-      command = { "fd", "--type=f", "--no-follow", "-e", search_term:sub(2), ".", search_path }
+      command = { fd.binary, "--type=f", "--no-follow", "-e", search_term:sub(2), ".", search_path }
     else -- 'name'
-      command = { "fd", "--type=f", "--no-follow", "--glob", search_term, ".", search_path }
+      command = { fd.binary, "--type=f", "--no-follow", "--glob", search_term, ".", search_path }
     end
     files = vim.fn.systemlist(command)
     if vim.v.shell_error == 0 then
@@ -56,8 +67,8 @@ local find_files = function(search_path, search_term, search_type)
     end
   end
 
-  if vim.fn.executable("git") == 1 and vim.fn.isdirectory(util.join_path(search_path, ".git")) then
-    command = { "git", "-C", search_path, "ls-files", "--cached", "--others", "--exclude-standard" }
+  if git and vim.fn.isdirectory(util.join_path(search_path, ".git")) then
+    command = { git.binary, "-C", search_path, "ls-files", "--cached", "--others", "--exclude-standard" }
     local all_files = vim.fn.systemlist(command)
     if vim.v.shell_error == 0 then
       local results = {}
@@ -192,7 +203,7 @@ end
 -- @return (table|nil) A list of match objects, or nil if rg is not available or finds nothing.
 --   Each object contains: { file = absolute_path, lnum = line_number, text = text_of_line }
 M.find_backlinks = function(search_path, target_filename)
-  if vim.fn.executable("rg") ~= 1 then
+  if not rg then
     return nil -- Ripgrep is required for this enhanced search.
   end
 
@@ -210,7 +221,7 @@ M.find_backlinks = function(search_path, target_filename)
   local pattern = wikilink_part .. "|" .. mdlink_part
 
   local command = {
-    "rg",
+    rg.binary,
     "--vimgrep",
     "--type",
     "markdown",

--- a/lua/neowiki/health.lua
+++ b/lua/neowiki/health.lua
@@ -10,13 +10,6 @@ local warn = vim.health.warn
 local error = vim.health.error
 local info = vim.health.info
 
---- Checks if a specific executable is available in the system path.
--- @param tool (string) The name of the executable to check (e.g., "rg").
--- @return (boolean) True if the tool is executable, false otherwise.
-local function check_external_tool(tool)
-  return vim.fn.executable(tool) == 1
-end
-
 ---
 -- Runs the health check for the neowiki plugin.
 -- Validates external tools, dependencies, and configuration paths.
@@ -25,10 +18,16 @@ end
 M.check = function()
   start("neowiki: External Tools")
 
+  local tools = {
+    fd  = { name = "fd", binaries = { "fd", "fdfind" } },
+    git = { name = "git" },
+    rg  = { name = "rg" },
+  }
+
   local tool_status = {
-    rg = check_external_tool("rg"),
-    fd = check_external_tool("fd"),
-    git = check_external_tool("git"),
+    rg = util.check_binary_installed(tools.rg),
+    fd = util.check_binary_installed(tools.fd),
+    git = util.check_binary_installed(tools.git),
   }
 
   if tool_status.rg then
@@ -38,7 +37,7 @@ M.check = function()
   end
 
   if tool_status.fd then
-    ok("fd: Installed")
+    ok("fd (" .. tool_status.fd.binary .. "): Installed")
   else
     warn("fd: Not found")
   end

--- a/lua/neowiki/util.lua
+++ b/lua/neowiki/util.lua
@@ -338,7 +338,7 @@ end
 -- Adapted binary check from:
 -- https://github.com/nvim-telescope/telescope.nvim/blob/5255aa27c422de944791318024167ad5d40aad20/lua/telescope/health.lua#L35-L50
 --
--- @param package (table) Program table with name and optional binary table
+-- @param program (table) Program table with name and optional binaries table
 -- @return (table) Table content: {exists, binary, version}
 --
 M.check_binary_installed = function(program)

--- a/lua/neowiki/util.lua
+++ b/lua/neowiki/util.lua
@@ -334,4 +334,28 @@ M.sanitize_filename = function(name)
   return sanitized
 end
 
+-- Get correct binary name on every system and distribution that uses different names for various reasons.
+-- Adapted binary check from:
+-- https://github.com/nvim-telescope/telescope.nvim/blob/5255aa27c422de944791318024167ad5d40aad20/lua/telescope/health.lua#L35-L50
+--
+-- @param package (table) Program table with name and optional binary table
+-- @return (table) Table content: {exists, binary, version}
+--
+M.check_binary_installed = function(program)
+  local binaries = program.binaries or { program.name }
+  for _, binary in ipairs(binaries) do
+    local found = vim.fn.executable(binary) == 1
+    if not found and is_win then
+      binary = binary .. ".exe"
+      found = vim.fn.executable(binary) == 1
+    end
+    if found then
+      local handle = io.popen(binary .. " --version")
+      local binary_version = handle:read "*a"
+      handle:close()
+      return { exists = true, binary = binary, version = binary_version }
+    end
+  end
+end
+
 return M

--- a/lua/neowiki/util.lua
+++ b/lua/neowiki/util.lua
@@ -339,7 +339,7 @@ end
 -- https://github.com/nvim-telescope/telescope.nvim/blob/5255aa27c422de944791318024167ad5d40aad20/lua/telescope/health.lua#L35-L50
 --
 -- @param program (table) Program table with name and optional binaries table
--- @return (table) Table content: {exists, binary, version}
+-- @return (table) Table content: {exists, binary}
 --
 M.check_binary_installed = function(program)
   local binaries = program.binaries or { program.name }
@@ -350,10 +350,7 @@ M.check_binary_installed = function(program)
       found = vim.fn.executable(binary) == 1
     end
     if found then
-      local handle = io.popen(binary .. " --version")
-      local binary_version = handle:read "*a"
-      handle:close()
-      return { exists = true, binary = binary, version = binary_version }
+      return { exists = true, binary = binary }
     end
   end
 end


### PR DESCRIPTION
Extends the binary tool check to allow specifying different tool binary names e.g. `fd` and `fdfind` (debian)

This adds a util function that returns the correct binary name for a tool.