### PR TITLE
Feature/rewrite treesitter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags
+.nvim.lua

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ lua vim.keymap.set("n", "<leader>wT", require("neowiki").open_wiki_new_tab, { de
 `neowiki.nvim` enhances file searching with modern command-line tools for optimal performance. While optional, installing `ripgrep` (`rg`) is highly recommended for efficient page listing and backlink updates. If not found, the plugin falls back to a native Lua search.
 
 ### Functional Enhancements
-* `nvim-treesitter`: Strongly recommended. `neowiki.nvim` uses the `markdown` and `markdown_inline` parsers to robustly detect and parse links, ensuring that links inside code blocks or other ignored regions are handled correctly.
+* `Treesitter`: Strongly recommended. `neowiki.nvim` uses the `markdown` and `markdown_inline` parsers to robustly detect and parse links, ensuring that links inside code blocks or other ignored regions are handled correctly.
 - [*vim-repeat*](https://github.com/tpope/vim-repeat): Enables repeating GTD actions (e.g., task creation and completion with `<leader>wt`) using the dot (`.`) command.
 
 ## 📝 Usage

--- a/doc/neowiki.txt
+++ b/doc/neowiki.txt
@@ -114,7 +114,7 @@ native Lua-based search method.
 
 OTHER DEPENDENCIES
 ------------------
-- ***nvim-treesitter***
+- ***Treesitter***
   Strongly recommended. neowiki.nvim uses Treesitter parsers (`markdown` and
   `markdown_inline`) to robustly detect and parse links, ensuring that links
   inside code blocks or other ignored regions are handled correctly.

--- a/lua/neowiki/core/link.lua
+++ b/lua/neowiki/core/link.lua
@@ -23,6 +23,57 @@ local function is_link_node(node_type)
     or node_type == "image"
 end
 
+-- Partially re-implement (copy) legacy `nvim-treesitter.ts_utils.get_node_at_cursor`
+-- `https://github.com/nvim-treesitter/nvim-treesitter/blob/cf12346a3414fa1b06af75c79faebe7f76df080a/lua/nvim-treesitter/ts_utils.lua#L163`
+local function get_root_for_position(line, col, root_lang_tree)
+  local lang_tree = root_lang_tree:language_for_range({ line, col, line, col })
+
+  while true do
+    for _, tree in pairs(lang_tree:trees()) do
+      local root = tree:root()
+
+      if root and vim.treesitter.is_in_node_range(root, line, col) then
+        return root, tree, lang_tree
+      end
+    end
+
+    if lang_tree == root_lang_tree then
+      break
+    end
+
+    -- This case can happen when the cursor is at the start of a line that ends a injected region,
+    -- e.g., the first `]` in the following lua code:
+    -- ```
+    -- vim.cmd[[
+    -- ]]
+    -- ```
+    lang_tree = lang_tree:parent() -- NOTE: parent() method is private
+  end
+
+  -- This isn't a likely scenario, since the position must belong to a tree somewhere.
+  return nil, nil, lang_tree
+end
+
+local function get_node_at_cursor()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local cursor_range = { cursor[1] - 1, cursor[2] }
+
+  local buf = vim.api.nvim_win_get_buf(0)
+  local root_lang_tree = vim.treesitter.get_parser(buf)
+  if not root_lang_tree then
+    return
+  end
+
+  local root ---@type TSNode|nil
+  root = get_root_for_position(cursor_range[1], cursor_range[2], root_lang_tree)
+
+  if not root then
+    return
+  end
+
+  return root:named_descendant_for_range(cursor_range[1], cursor_range[2], cursor_range[1], cursor_range[2])
+end
+
 --- Uses Treesitter to extract the link target under the cursor.
 --- Returns nil if Treesitter is unavailable, disabled, or no link is found.
 ---@return string|nil The raw link target text, or nil.
@@ -31,12 +82,7 @@ local function get_ts_link_target()
     return nil
   end
 
-  local ok, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
-  if not ok then
-    return nil
-  end
-
-  local node = ts_utils.get_node_at_cursor()
+  local node = get_node_at_cursor()
   if not node then
     return nil
   end

--- a/lua/neowiki/health.lua
+++ b/lua/neowiki/health.lua
@@ -32,30 +32,20 @@ M.check = function()
 
   start("neowiki: Dependencies")
 
-  local has_ts, _ = pcall(require, "nvim-treesitter")
-  if not has_ts then
-    warn("nvim-treesitter: Not installed")
-    info("Link detection will use Regex fallback (less robust).")
-  else
-    ok("nvim-treesitter: Installed")
-    local parsers = require("nvim-treesitter.parsers")
-    local required_parsers = { "markdown", "markdown_inline" }
-    for _, parser in ipairs(required_parsers) do
-      -- The nvim-treesitter parser module completely changed in the last major release. Therefore
-      -- we first check for the old `has_parser` function and then check on the module table
-      -- directly as the new release returns a table with the parser.
-      local has_parser
-      if _G["nvim-treesitter.parsers.has_parser"] then
-        has_parser = parsers.has_parser(parser)
-      else
-        has_parser = parsers[parser]
-      end
-      if has_parser then
-        ok(string.format(" - Parser '%s': Installed", parser))
-      else
-        warn(string.format(" - Parser '%s': Missing", parser))
-        info(string.format("   Run :TSInstall %s", parser))
-      end
+  local required_parsers = { "markdown", "markdown_inline" }
+  for _, parser in ipairs(required_parsers) do
+    -- Check if the queries are in the runtime paths and the parser are installed.
+    -- Query the path to make it independent of the treesitter support inside neovim.
+    -- Treesitter support in neovim is changing quickly therefore internal function can't be relied on beyond
+    -- a major version. This approach is tested beginning with neovim 0.7
+    local has_parser = vim.api.nvim_exec([[echo nvim_get_runtime_file("parser/]] .. parser .. [[.*", v:true)]], true)
+    local has_queries = vim.api.nvim_exec([[echo nvim_get_runtime_file("queries/]] .. parser .. [[", v:true)]], true)
+    if string.find(has_parser, parser) ~= nil and string.find(has_queries, parser) ~= nil then
+      ok(string.format(" - Parser '%s': Installed", parser))
+    else
+      warn(string.format(" - Parser '%s': Missing", parser))
+      info("   Install parser using a treesitter manager plugin like `neovim-treesitter/nvim-treesitter`.")
+      info("   Or manual install the parser and queries.")
     end
   end
 


### PR DESCRIPTION
This PR rewrites the Treesitter support to only use neovim internal functionality. It copies a minimal version of `get_node_at_cursor` function from the legacy master branch of the archived [`nvim-treesitter/nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter) plugin.

The health check is tested to work with neovim 0.7 and the `core.link` functionality work with neovim 0.10. For neovim 0.10 and 0.11 the treesitter support needs to be enabled manually.

(PS: Thanks for fixing the little missed mishap in the other PR)